### PR TITLE
chore(dx): reproducible setup for fresh clones

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,8 @@ env:
   FOUNDRY_PROFILE: ci
 
 jobs:
-  check:
-    name: Foundry project
+  solidity:
+    name: Solidity
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,3 +36,23 @@ jobs:
 
       - name: Run Forge tests
         run: forge test -vvv
+
+  python:
+    name: Python
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run Python tests
+        run: PYTHONPATH=research pytest research/tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ aiUtils/
 *.pyc
 *.pyo
 !research/**/*.py
+!conftest.py
+!scripts/ffi/**/*.py
 *.pyd
 __pycache__/
 *.so

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.PHONY: install test-sol test-py test notebooks clean
+
+# ── Setup ────────────────────────────────────────────────────────────
+install:
+	git submodule update --init --recursive
+	python3 -m venv .venv
+	.venv/bin/pip install -e ".[dev]"
+	.venv/bin/python -m ipykernel install --user --name=thetaswap \
+		--env PYTHONPATH "$(CURDIR)/research"
+
+# ── Solidity ─────────────────────────────────────────────────────────
+test-sol:
+	forge build
+	forge test
+
+# ── Python ───────────────────────────────────────────────────────────
+test-py:
+	PYTHONPATH=research .venv/bin/pytest research/tests -v
+
+# ── All tests ────────────────────────────────────────────────────────
+test: test-sol test-py
+
+# ── Notebooks (headless execute) ─────────────────────────────────────
+notebooks:
+	@for nb in research/notebooks/*.ipynb; do \
+		echo "Executing $$nb ..."; \
+		PYTHONPATH=research .venv/bin/jupyter nbconvert \
+			--to notebook --execute \
+			--ExecutePreprocessor.timeout=300 \
+			--ExecutePreprocessor.kernel_name=thetaswap \
+			"$$nb" --output /dev/null; \
+	done
+	@echo "All notebooks passed."
+
+# ── Clean ────────────────────────────────────────────────────────────
+clean:
+	rm -rf out/ cache/

--- a/README.md
+++ b/README.md
@@ -1,66 +1,93 @@
-## Foundry
+# ThetaSwap Core
 
-**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+Fee concentration insurance protocol for Uniswap V4 passive LPs.
 
-Foundry consists of:
+## Prerequisites
 
-- **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
-- **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
-- **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
-- **Chisel**: Fast, utilitarian, and verbose solidity REPL.
+- [Foundry](https://book.getfoundry.sh/getting-started/installation) (forge, cast, anvil)
+- Python >= 3.11
 
-## Documentation
+## Quick Start
 
-https://book.getfoundry.sh/
+```bash
+# Clone with submodules
+git clone --recurse-submodules <repo-url>
+cd thetaSwap-core-dev
 
-## Usage
+# One-command setup (venv + deps + Jupyter kernel)
+make install
 
-### Build
-
-```shell
-$ forge build
+# Run all tests
+make test
 ```
 
-### Test
+## Solidity (Fee Concentration Index)
 
-```shell
-$ forge test
+```bash
+forge build          # compile contracts
+forge test           # run Solidity tests
+forge test -vvv      # verbose output
 ```
 
-### Format
+Contracts live in `src/fee-concentration-index/`. Tests in `test/fee-concentration-index/`.
 
-```shell
-$ forge fmt
+## Python (Econometrics + Backtest)
+
+```bash
+# Activate venv
+source .venv/bin/activate
+
+# Run Python tests
+make test-py
+# or directly:
+PYTHONPATH=research pytest research/tests -v
+
+# Execute all notebooks headless
+make notebooks
 ```
 
-### Gas Snapshots
+Research code lives in `research/`:
+- `research/econometrics/` — hazard model, duration model, ingestion
+- `research/backtest/` — insurance backtest engine
+- `research/data/` — cached Dune query results
+- `research/notebooks/` — reproducible result notebooks
+- `research/tests/` — Python test suite
 
-```shell
-$ forge snapshot
+### Manual Python Setup (without Make)
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+
+# For notebooks: register a Jupyter kernel
+python -m ipykernel install --user --name=thetaswap \
+    --env PYTHONPATH "$(pwd)/research"
 ```
 
-### Anvil
+### Running Notebooks
 
-```shell
-$ anvil
+Notebooks expect a kernel with `PYTHONPATH` pointing to `research/`. The `make install` command sets this up automatically. To run interactively:
+
+```bash
+source .venv/bin/activate
+jupyter lab --notebook-dir=research/notebooks
 ```
 
-### Deploy
+Select the **thetaswap** kernel when opening notebooks.
 
-```shell
-$ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
+## Project Structure
+
 ```
-
-### Cast
-
-```shell
-$ cast <subcommand>
-```
-
-### Help
-
-```shell
-$ forge --help
-$ anvil --help
-$ cast --help
+src/fee-concentration-index/   Solidity hook contract
+test/fee-concentration-index/  Solidity tests (Foundry)
+research/
+  econometrics/                Hazard + duration models
+  backtest/                    Insurance backtest engine
+  data/                        Cached Dune query data
+  notebooks/                   Result notebooks (4)
+  tests/                       Python tests (pytest)
+specs/                         LaTeX specs + econometric model
+docs/plans/                    Implementation plans
+lib/                           Foundry dependencies (submodules)
 ```

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+"""Root conftest: add research/ to sys.path so econometrics/backtest are importable."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "research"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,22 +3,32 @@ requires = ["setuptools>=68.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "thetaswap-simulation"
+name = "thetaswap-research"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
+    "jax[cpu]>=0.4",
     "numpy>=1.24",
     "scipy>=1.11",
     "matplotlib>=3.7",
-    "jupyter>=1.0",
+    "httpx>=0.27",
+    "python-dotenv>=1.0",
+    "eth_abi>=5.0",
+    "pycryptodome>=3.20",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0"]
+dev = [
+    "pytest>=7.0",
+    "jupyter>=1.0",
+    "nbconvert>=7.0",
+    "ipykernel>=6.0",
+]
 
 [tool.setuptools.packages.find]
-include = ["simulation*"]
+where = ["research"]
+include = ["econometrics*", "backtest*"]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+testpaths = ["research/tests"]
 addopts = "--import-mode=importlib"


### PR DESCRIPTION
## Summary
- **pyproject.toml**: real Python deps (jax, httpx, dotenv, eth_abi), `research/` package discovery, correct `testpaths`
- **conftest.py**: adds `research/` to `sys.path` — no `PYTHONPATH` needed for pytest
- **Makefile**: `make install` (venv + deps + kernel), `make test`, `make notebooks`
- **CI**: adds Python test job to `.github/workflows/test.yml` (runs alongside Solidity)
- **README.md**: full setup instructions for Solidity + Python stacks
- **.gitignore**: allows `conftest.py` at root

## Problem
A fresh clone required undocumented `PYTHONPATH=research`, manual dep hunting, and a pre-existing `uhi8` Jupyter kernel. No Python CI existed.

## Test plan
- [x] `pytest research/tests -v` passes (113/113) without PYTHONPATH
- [x] `forge test` passes (38/39, 1 expected fork test skip)
- [x] All 4 notebooks execute and reproduce PDF spec values
- [ ] CI workflow runs both Solidity and Python jobs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)