### PR TITLE
demo: storytelling console logs for sol-test-demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ sol-test:
 		--no-match-test "test_integrationNativeV4_unit_equalCapitalDurationHeterogeneousLps_twoSwaps_deltaPlusMustBeZero|test_integrationNativeV4_unit_twoHeteroCapitalPartialExit_registryHasActivePosition"
 
 sol-test-demo:
-	forge test --match-path "test/fee-concentration-index-v2/protocols/uniswapV4/*" -vv
+	forge test --match-path "test/fee-concentration-index-v2/protocols/uniswapV4/*" \
+		--match-test "twoHomogeneousLps_oneSwap|threeSwaps_deltaPlusCapturesCrowdOut|twoDifferentOnlyCapitalHeterogenousLps_oneSwap" -vv
 
 # ── Python ───────────────────────────────────────────────────────────
 test-py:

--- a/research/data/fixtures/simulator/equal_capital_hetero_duration.json
+++ b/research/data/fixtures/simulator/equal_capital_hetero_duration.json
@@ -71,7 +71,13 @@
     "thetaSum": "0x60000000000000000000000000000000",
     "removedPosCount": 2,
     "atNull": "0x4e6238502484b9f40c86450c8695591c",
-    "deltaPlus": "0x0"
+    "deltaPlus": "0x0",
+    "readable": {
+      "deltaPlus": "0.000000",
+      "indexA": "0.306186",
+      "atNull": "0.306186",
+      "thetaSum": "0.375000"
+    }
   },
   "removals": [
     {

--- a/research/data/fixtures/simulator/jit_crowdout_three_swaps.json
+++ b/research/data/fixtures/simulator/jit_crowdout_three_swaps.json
@@ -81,7 +81,13 @@
     "thetaSum": "0x8295fad40a57eb50295fad40a57eb502",
     "removedPosCount": 2,
     "atNull": "0x5b6b5996809899d6584bba8da4e702d0",
-    "deltaPlus": "0x4784b4ab4198210da40395d8cd20cab8"
+    "deltaPlus": "0x4784b4ab4198210da40395d8cd20cab8",
+    "readable": {
+      "deltaPlus": "0.279369",
+      "indexA": "0.636475",
+      "atNull": "0.357107",
+      "thetaSum": "0.510101"
+    }
   },
   "removals": [
     {

--- a/research/data/fixtures/simulator/sole_provider_no_swaps.json
+++ b/research/data/fixtures/simulator/sole_provider_no_swaps.json
@@ -36,7 +36,13 @@
     "thetaSum": "0x0",
     "removedPosCount": 0,
     "atNull": "0x0",
-    "deltaPlus": "0x0"
+    "deltaPlus": "0x0",
+    "readable": {
+      "deltaPlus": "0.000000",
+      "indexA": "0.000000",
+      "atNull": "0.000000",
+      "thetaSum": "0.000000"
+    }
   },
   "removals": [
     {

--- a/research/data/fixtures/simulator/sole_provider_no_swaps_repeated.json
+++ b/research/data/fixtures/simulator/sole_provider_no_swaps_repeated.json
@@ -68,7 +68,13 @@
     "thetaSum": "0x0",
     "removedPosCount": 0,
     "atNull": "0x0",
-    "deltaPlus": "0x0"
+    "deltaPlus": "0x0",
+    "readable": {
+      "deltaPlus": "0.000000",
+      "indexA": "0.000000",
+      "atNull": "0.000000",
+      "thetaSum": "0.000000"
+    }
   },
   "removals": [
     {

--- a/research/data/fixtures/simulator/sole_provider_one_swap.json
+++ b/research/data/fixtures/simulator/sole_provider_one_swap.json
@@ -42,7 +42,13 @@
     "thetaSum": "0x1c71c71c71c71c71c71c71c71c71c71c",
     "removedPosCount": 1,
     "atNull": "0x55555555555555555555555555555554",
-    "deltaPlus": "0x0"
+    "deltaPlus": "0x0",
+    "readable": {
+      "deltaPlus": "0.000000",
+      "indexA": "0.333333",
+      "atNull": "0.333333",
+      "thetaSum": "0.111111"
+    }
   },
   "removals": [
     {

--- a/research/data/fixtures/simulator/two_hetero_capital_one_swap.json
+++ b/research/data/fixtures/simulator/two_hetero_capital_one_swap.json
@@ -61,7 +61,13 @@
     "thetaSum": "0x38e38e38e38e38e38e38e38e38e38e38",
     "removedPosCount": 2,
     "atNull": "0x3c56fbbbfdf4cc2c1dd4833bd1c394df",
-    "deltaPlus": "0x3439117e57116836da3a78442e30963"
+    "deltaPlus": "0x3439117e57116836da3a78442e30963",
+    "readable": {
+      "deltaPlus": "0.012750",
+      "indexA": "0.248452",
+      "atNull": "0.235702",
+      "thetaSum": "0.222222"
+    }
   },
   "removals": [
     {

--- a/research/data/fixtures/simulator/two_hetero_capital_partial_exit.json
+++ b/research/data/fixtures/simulator/two_hetero_capital_partial_exit.json
@@ -56,6 +56,12 @@
     "removedPosCount": 1,
     "atNull": "0x55555555555555555555555555555554",
     "deltaPlus": "0x0",
+    "readable": {
+      "deltaPlus": "0.000000",
+      "indexA": "0.111111",
+      "atNull": "0.333333",
+      "thetaSum": "0.111111"
+    },
     "ranges": [
       {
         "tickLower": -60,

--- a/research/data/fixtures/simulator/two_homogeneous_lps_one_swap.json
+++ b/research/data/fixtures/simulator/two_homogeneous_lps_one_swap.json
@@ -61,7 +61,13 @@
     "thetaSum": "0x38e38e38e38e38e38e38e38e38e38e38",
     "removedPosCount": 2,
     "atNull": "0x3c56fbbbfdf4cc2c1dd4833bd1c394df",
-    "deltaPlus": "0x0"
+    "deltaPlus": "0x0",
+    "readable": {
+      "deltaPlus": "0.000000",
+      "indexA": "0.235702",
+      "atNull": "0.235702",
+      "thetaSum": "0.222222"
+    }
   },
   "removals": [
     {

--- a/research/simulator/fixtures.py
+++ b/research/simulator/fixtures.py
@@ -48,6 +48,12 @@ def _agent_to_dict(agent: Agent) -> dict[str, Any]:
     }
 
 
+def _q128_to_readable(val: int) -> str:
+    """Convert Q128 fixed-point to human-readable decimal string."""
+    Q128 = 1 << 128
+    return f"{val / Q128:.6f}"
+
+
 def _metrics_to_dict(m: FCIMetrics) -> dict[str, Any]:
     """Serialize metrics as hex strings (Q128 values) for Solidity parsing."""
     d: dict[str, Any] = {
@@ -57,6 +63,12 @@ def _metrics_to_dict(m: FCIMetrics) -> dict[str, Any]:
         "removedPosCount": m.removed_pos_count,
         "atNull": hex(m.at_null),
         "deltaPlus": hex(m.delta_plus),
+        "readable": {
+            "deltaPlus": _q128_to_readable(m.delta_plus),
+            "indexA": _q128_to_readable(m.index_a),
+            "atNull": _q128_to_readable(m.at_null),
+            "thetaSum": _q128_to_readable(m.theta_sum),
+        },
     }
     if m.epochs:
         d["epochs"] = [

--- a/test/fee-concentration-index-v2/protocols/uniswapV4/NativeV4FeeConcentrationIndex.integration.t.sol
+++ b/test/fee-concentration-index-v2/protocols/uniswapV4/NativeV4FeeConcentrationIndex.integration.t.sol
@@ -262,10 +262,20 @@ contract NativeV4FeeConcentrationIndex_IntegrationTest is PosmTestSetup {
         // Facet registration
         assertEq(actualFacet, address(facet), "getRegisteredProtocolFacet() mismatch");
 
-        // ── Storytelling output ──
+        // ── Storytelling output: raw Q128 + human-readable from Python simulator ──
+        string memory readableDeltaPlus = vm.parseJsonString(json, ".expected.readable.deltaPlus");
+        string memory readableIndexA = vm.parseJsonString(json, ".expected.readable.indexA");
+        string memory readableAtNull = vm.parseJsonString(json, ".expected.readable.atNull");
+        string memory readableThetaSum = vm.parseJsonString(json, ".expected.readable.thetaSum");
+
         console2.log("  == RESULT: DeltaPlus =", uint256(actualDeltaPlus));
-        console2.log("  == RESULT: IndexA =", uint256(actualIndexA), "AtNull =", uint256(actualAtNull));
+        console2.log("     -> DeltaPlus (decimal):", readableDeltaPlus);
+        console2.log("  == RESULT: IndexA =", uint256(actualIndexA));
+        console2.log("     -> IndexA (decimal):", readableIndexA);
+        console2.log("  == RESULT: AtNull =", uint256(actualAtNull));
+        console2.log("     -> AtNull (decimal):", readableAtNull);
         console2.log("  == RESULT: ThetaSum =", actualThetaSum, "RemovedPosCount =", actualRemovedPosCount);
+        console2.log("     -> ThetaSum (decimal):", readableThetaSum);
         console2.log("  == RESULT: DeltaPlusEpoch =", uint256(actualDeltaPlusEpoch), "(must match DeltaPlus within same epoch)");
 
         // ── Cross-getter consistency ──
@@ -355,13 +365,35 @@ contract NativeV4FeeConcentrationIndex_IntegrationTest is PosmTestSetup {
     }
 
     function test_integrationNativeV4_unit_twoHomogeneousLps_oneSwap_deltaPlusMustBeZero() public {
-        console2.log("--- EQUILIBRIUM: Two identical LPs, equal capital. DeltaPlus = 0 ---");
+        console2.log("=======================================================================");
+        console2.log("  EQUILIBRIUM: Two identical LPs, equal capital");
+        console2.log("=======================================================================");
+        console2.log("  Setup: 2 LPs each deposit 1e18 liquidity on the same tick range [-60,60]");
+        console2.log("  1 swap executes. Both LPs capture 50% of fees (xK = 0.5 each)");
+        console2.log("  Both exit at the same block -> identical duration (9 blocks, thetaK = 0.1111)");
+        console2.log("  Since fee shares are equal, no LP is crowded out");
+        console2.log("  Expected: IndexA = AtNull = 0.2357 -> DeltaPlus = 0");
+        console2.log("-----------------------------------------------------------------------");
         _runFixture("two_homogeneous_lps_one_swap");
+        console2.log("-----------------------------------------------------------------------");
+        console2.log("  Conclusion: FCI correctly returns zero concentration for symmetric competition");
+        console2.log("=======================================================================");
     }
 
     function test_integrationNativeV4_unit_twoDifferentOnlyCapitalHeterogenousLps_oneSwap_deltaPlusGtZero() public {
-        console2.log("--- CROWDING-OUT: Two LPs, unequal capital. Larger LP captures more fees -> DeltaPlus > 0 ---");
+        console2.log("=======================================================================");
+        console2.log("  MILD CROWDING-OUT: Two LPs, unequal capital (1:2 ratio)");
+        console2.log("=======================================================================");
+        console2.log("  Setup: lp0 deposits 1e18, lp1 deposits 2e18 on the same range [-60,60]");
+        console2.log("  1 swap executes. lp0 captures 33% of fees (xK=0.33), lp1 captures 67% (xK=0.67)");
+        console2.log("  Both exit at the same block -> identical duration (9 blocks)");
+        console2.log("  The larger LP takes a disproportionate fee share, mild asymmetry");
+        console2.log("  Expected: IndexA = 0.2485, AtNull = 0.2357 -> DeltaPlus = 0.0128");
+        console2.log("-----------------------------------------------------------------------");
         _runFixture("two_hetero_capital_one_swap");
+        console2.log("-----------------------------------------------------------------------");
+        console2.log("  Conclusion: DeltaPlus > 0 but small. Capital asymmetry alone produces mild concentration");
+        console2.log("=======================================================================");
     }
 
     function test_integrationNativeV4_unit_twoHeteroCapitalPartialExit_registryHasActivePosition() public {
@@ -375,7 +407,19 @@ contract NativeV4FeeConcentrationIndex_IntegrationTest is PosmTestSetup {
     }
 
     function test_integrationNativeV4_unit_twoDifferentHeterogenousLps_threeSwaps_deltaPlusCapturesCrowdOut() public {
-        console2.log("--- CROWDING-OUT: JIT-style short-lived position crowds out passive LP across 3 swaps ---");
+        console2.log("=======================================================================");
+        console2.log("  CROWDING-OUT: JIT sniper vs passive LP (1:9 capital, 99 vs 2 blocks)");
+        console2.log("=======================================================================");
+        console2.log("  Setup: lp0 (passive) deposits 1e18, stays 99 blocks");
+        console2.log("  lp1 (JIT) deposits 9e18 just before swap 2, exits after 2 blocks");
+        console2.log("  During overlap: JIT captures 90% of fees (xK=0.9), passive only 10% (xK=0.1)");
+        console2.log("  JIT's theta-weight is high (thetaK=0.5 for 2 blocks) vs passive (thetaK=0.01 for 99 blocks)");
+        console2.log("  3 swaps total: 1 before JIT, 1 during JIT overlap, 1 after JIT exits");
+        console2.log("  Expected: IndexA = 0.6365, AtNull = 0.3571 -> DeltaPlus = 0.2794");
+        console2.log("-----------------------------------------------------------------------");
         _runFixture("jit_crowdout_three_swaps");
+        console2.log("-----------------------------------------------------------------------");
+        console2.log("  Conclusion: DeltaPlus = 0.2794 - heavy concentration. FCI captures the JIT crowd-out");
+        console2.log("=======================================================================");
     }
 }


### PR DESCRIPTION
## Summary
- Filter `sol-test-demo` to 3 key tests: equilibrium, mild crowding-out, JIT crowding-out
- Add readable decimal fields to fixture JSON (generated by Python simulator)
- Each test tells the economic story: setup, fee shares, expected outcome, conclusion
- Raw Q128 values shown alongside human-readable decimals

## Test plan
- [x] `make sol-test-demo` passes all 3 tests with storytelling output

🤖 Generated with [Claude Code](https://claude.com/claude-code)